### PR TITLE
Remove enableByDefault = false option

### DIFF
--- a/src/main/java/com/statussocket/StatusSocketPlugin.java
+++ b/src/main/java/com/statussocket/StatusSocketPlugin.java
@@ -27,8 +27,7 @@ import javax.inject.Inject;
 @PluginDescriptor(
 	name = "Status Socket",
 	description = "Actively logs the player status to a remote server.",
-	tags = {"status", "socket"},
-	enabledByDefault = false
+	tags = {"status", "socket"}
 )
 public class StatusSocketPlugin extends Plugin
 {


### PR DESCRIPTION
It's confusing for users to install plugins which don't enable themselves upon installation.

✌